### PR TITLE
make init-generate do a final write when reaching file eof

### DIFF
--- a/yaml_generate.go
+++ b/yaml_generate.go
@@ -41,10 +41,12 @@ func (generator *YMLInitGenerator) generateSingleFile(fullPath string, sourcePat
 
 			line, err = r.ReadString(10) // 0x0A separator = newline
 			if err == io.EOF {
+				generator.output.Write([]byte(indent + line))
 				generator.output.Write([]byte(indent + "\n"))
 				break
 			} else if err != nil {
 				log.Error(err.Error())
+				generator.output.Write([]byte(indent + "\n"))
 				return false
 			}
 		}


### PR DESCRIPTION
the init yaml generator now does a final write when it reaches eof on a file, and it adds a newline if it hits an error.